### PR TITLE
if no match found, continue arraychecking

### DIFF
--- a/outputs_all_required/template_req.wdl
+++ b/outputs_all_required/template_req.wdl
@@ -1,9 +1,9 @@
 version 1.0
 
 # Replace the first URL here with the URL of the workflow to be checked.
-import "https://raw.githubusercontent.com/aofarrel/checker-WDL-templates/v0.8.0/outputs_all_required/example_req.wdl" as check_me
-import "https://raw.githubusercontent.com/aofarrel/checker-WDL-templates/v0.8.0/tasks/filecheck_task.wdl" as checker_file
-import "https://raw.githubusercontent.com/aofarrel/checker-WDL-templates/v0.8.0/tasks/arraycheck_task.wdl" as checker_array
+import "https://raw.githubusercontent.com/aofarrel/checker-WDL-templates/v0.8.1/outputs_all_required/example_req.wdl" as check_me
+import "https://raw.githubusercontent.com/aofarrel/checker-WDL-templates/v0.8.1/tasks/filecheck_task.wdl" as checker_file
+import "https://raw.githubusercontent.com/aofarrel/checker-WDL-templates/v0.8.1/tasks/arraycheck_task.wdl" as checker_array
 
 # If running this locally, you can import tasks with relative paths, like this:
 #import "example_req.wdl" as check_me

--- a/tasks/arraycheck_task.wdl
+++ b/tasks/arraycheck_task.wdl
@@ -31,13 +31,16 @@ task arraycheck_classic {
 				break
 			fi
 		done
-
-		if ! echo "$(cut -f1 -d' ' sum.txt)" $actual_truth | md5sum --check
-		then
-			if ~{fastfail}
+		if [ "$actual_truth" != "" ]; then
+			if ! echo "$(cut -f1 -d' ' sum.txt)" $actual_truth | md5sum --check
 			then
-				exit 1
+				if ~{fastfail}
+				then
+					exit 1
+				fi
 			fi
+		else
+			echo "A truth file was not found for $test_basename"
 		fi
 	done
 
@@ -59,6 +62,8 @@ task arraycheck_classic {
 
 task arraycheck_optional {
 	# Use this task when the ENTIRE array of test files may not exist
+	# Ideally this task should never be called if the test array does
+	# not exist... put a defined() check before calling this task.
 	# Note that disk size is based upon truth array * 2 now!
 	input {
 		Array[File]? test
@@ -84,13 +89,16 @@ task arraycheck_optional {
 				break
 			fi
 		done
-
-		if ! echo "$(cut -f1 -d' ' sum.txt)" $actual_truth | md5sum --check
-		then
-			if ~{fastfail}
+		if [ "$actual_truth" != "" ]; then
+			if ! echo "$(cut -f1 -d' ' sum.txt)" $actual_truth | md5sum --check
 			then
-				exit 1
+				if ~{fastfail}
+				then
+					exit 1
+				fi
 			fi
+		else
+			echo "A truth file was not found for $test_basename"
 		fi
 	done
 


### PR DESCRIPTION
avoids "no properly formatted md5 lines" error