### PR TITLE
Return 1 if a non fastfail mismatch

### DIFF
--- a/check_wf_outputs/outputs_some_optional/template_opt.wdl
+++ b/check_wf_outputs/outputs_some_optional/template_opt.wdl
@@ -14,7 +14,7 @@ version 1.0
 # Replace the first URL here with the URL of the workflow to be checked.
 import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v0.100.0/check_wf_outputs/outputs_some_optional/parent_opt.wdl" as check_me
 import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v0.100.0/checker_tasks/filecheck_task.wdl" as verify_file
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v0.100.0/checker_tasks/arraycheck_task.wdl" as verify_array
+import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/return-1-if-a-non-fastfail-mismatch/checker_tasks/arraycheck_task.wdl" as verify_array
 
 # If running this locally, you can import tasks with relative paths, like this:
 #import "parent_opt.wdl" as check_me

--- a/checker_tasks/arraycheck_task.wdl
+++ b/checker_tasks/arraycheck_task.wdl
@@ -90,7 +90,7 @@ task arraycheck_classic {
 	done
 
 	echo "Finished checking all files in test array." | tee -a report.txt
-	if [ "$failed_at_least_once" != "" ]
+	if [ "$failed_at_least_once" != "false" ]
 	then
 		echo "At least one file failed. Returning 1..."| tee -a report.txt
 		exit 1

--- a/checker_tasks/arraycheck_task.wdl
+++ b/checker_tasks/arraycheck_task.wdl
@@ -62,7 +62,6 @@ task arraycheck_classic {
 					then
 						echo "Test file not identical to truth file, but are within ~{tolerance}." | tee -a report.txt
 						echo "PASS" | tee -a report.txt
-						exit 0
 					else
 						echo "Test file varies beyond accepted tolerance of ~{tolerance}. FAIL" | tee -a report.txt
 						echo "FAIL" | tee -a report.txt

--- a/checker_tasks/arraycheck_task.wdl
+++ b/checker_tasks/arraycheck_task.wdl
@@ -78,7 +78,6 @@ task arraycheck_classic {
 					if ~{fastfail}
 					then
 						exit 1
-					fi
 					else
 						failed_at_least_once="true"
 					fi


### PR DESCRIPTION
In the non fastfail situation, the entire array will be gone through, but any failures will **not** result in the pipeline overall erroring out. The purpose of the non fastfail situation is not to suppress the error but to delay it until the entire array can be checked. This, combined with the fix that stops the first rdata file getting checked to return 0 if it passes, should allow for what I actually intended.