### PR TITLE
Add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ Cromwell.stderr.txt
 Cromwell.stdout.txt
 .DS_Store
 */cromwell-input/*
+output.txt
+*_checker/*
+_LAST
+*_wf/*

--- a/check_approximately_equals/fuzzycheck_RData.wdl
+++ b/check_approximately_equals/fuzzycheck_RData.wdl
@@ -52,7 +52,6 @@ workflow checker {
 		input:
 			test = testRDataarray,
 			truth = truthRDataarray,
-			truth = truthRDataarray,
 			rdata_check = true
 	}
 

--- a/check_approximately_equals/fuzzycheck_RData.wdl
+++ b/check_approximately_equals/fuzzycheck_RData.wdl
@@ -13,20 +13,20 @@ version 1.0
 # limitations under the License.
 
 ################################### NOTES ####################################
-# If running this locally, you can import tasks with relative paths, like this:
-#import "example_req.wdl" as check_me
-#import "../tasks/filecheck_task.wdl" as verify_file
-#import "../tasks/arraycheck_task.wdl" as verify_array
 #
 # There is no functional difference between "here's an array of files from
 # multiple different tasks" and "here's an array of files that was output 
 # from a single task," provided that in both cases ALL files within the array
 # AND the array itself are NOT optional. You do not need to know how many
 # files are in an array, but none of those files can have type File?.
+#
+# If running this locally, you can import tasks with relative paths, like this:
+import "../checker_tasks/filecheck_task.wdl" as verify_file
+import "../checker_tasks/arraycheck_task.wdl" as verify_array
 
 # Replace the first URL here with the URL of the workflow to be checked.
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
 
 
 workflow checker {

--- a/check_approximately_equals/fuzzycheck_RData.wdl
+++ b/check_approximately_equals/fuzzycheck_RData.wdl
@@ -52,6 +52,7 @@ workflow checker {
 		input:
 			test = testRDataarray,
 			truth = truthRDataarray,
+			truth = truthRDataarray,
 			rdata_check = true
 	}
 

--- a/check_wf_outputs/outputs_all_required/template_req.wdl
+++ b/check_wf_outputs/outputs_all_required/template_req.wdl
@@ -13,10 +13,6 @@ version 1.0
 # limitations under the License.
 
 ################################### NOTES ####################################
-# If running this locally, you can import tasks with relative paths, like this:
-#import "example_req.wdl" as check_me
-#import "../tasks/filecheck_task.wdl" as verify_file
-#import "../tasks/arraycheck_task.wdl" as verify_array
 #
 # There is no functional difference between "here's an array of files from
 # multiple different tasks" and "here's an array of files that was output 
@@ -25,9 +21,14 @@ version 1.0
 # files are in an array, but none of those files can have type File?.
 
 # Replace the first URL here with the URL of the workflow to be checked.
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/check_wf_outputs/outputs_all_required/parent_req.wdl" as check_me
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/check_wf_outputs/outputs_all_required/parent_req.wdl" as check_me
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
+
+# If running this locally, you can import tasks with relative paths, like this:
+import "parent_req.wdl" as check_me
+import "../../checker_tasks/filecheck_task.wdl" as verify_file
+import "../../checker_tasks/arraycheck_task.wdl" as verify_array
 
 workflow checker {
 	input {

--- a/check_wf_outputs/outputs_some_optional/template_opt.wdl
+++ b/check_wf_outputs/outputs_some_optional/template_opt.wdl
@@ -11,16 +11,6 @@ version 1.0
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Replace the first URL here with the URL of the workflow to be checked.
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/check_wf_outputs/outputs_some_optional/parent_opt.wdl" as check_me
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
-
-# If running this locally, you can import tasks with relative paths, like this:
-#import "parent_opt.wdl" as check_me
-#import "../../checker_tasks/filecheck_task.wdl" as verify_file
-#import "../../checker_tasks/arraycheck_task.wdl" as verify_array
-
 # In summary:
 # Workflow outputs single Array[File] --> call arraycheck_classic
 # Workflow outputs several Files, all of which are required --> call arraycheck_classic
@@ -28,6 +18,16 @@ import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0
 # Workflow outputs several Files, some of which are required --> call arraycheck_classic with select_first()
 # Workflow outputs single File, which is required --> call filecheck
 # Workflow outputs optional File --> call filecheck but put in a defined() check before the task call or use select_first()
+
+# Replace the first URL here with the URL of the workflow to be checked.
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/check_wf_outputs/outputs_some_optional/parent_opt.wdl" as check_me
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
+
+# If running this locally, you can import tasks with relative paths, like this:
+import "parent_opt.wdl" as check_me
+import "../../checker_tasks/filecheck_task.wdl" as verify_file
+import "../../checker_tasks/arraycheck_task.wdl" as verify_array
 
 
 workflow checker {

--- a/checker_tasks/arraycheck_task.wdl
+++ b/checker_tasks/arraycheck_task.wdl
@@ -26,7 +26,7 @@ task arraycheck_classic {
 		Array[File] test
 		Array[File] truth
 		Boolean fastfail = false  # should we exit out upon first mismatch?
-		Boolean rdata_check = false  # check with all.equal() upon failure; only use with RData files!
+		Boolean rdata_check = false  # check with all.equal() fdupon failure; only use with RData files!
 		Float tolerance = 0.00000001  # tolerance to use for all.equal(); default is 1.0E-8
 	}
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,32 +5,37 @@ import datetime
 import sys
 import os
 
-
+skip_syntax_check = True # just for debugging
 _failed_ = False
 
-print("[%s] Check syntax via womtool..." % datetime.datetime.now())
-for root, dirs, files in os.walk(".", topdown=True):
-	for file in files:
-		if file.endswith(".wdl"):
-			this_wdl = os.path.join(root, file)
-			print("[%s] Checking %s..." % (datetime.datetime.now(), this_wdl))
-			try:
-				subprocess.check_call(["java", "-jar", "/Applications/womtool-76.jar",
-				 "validate", "%s" % this_wdl], stdout=subprocess.DEVNULL)
-			except subprocess.CalledProcessError as oops:
-				# womtool will print more useful stderr to command line
-				print("ERROR - womtool returned %s" % oops.returncode)
-				_failed_ = True
+if not skip_syntax_check:
+	print("[%s] Check syntax via womtool..." % datetime.datetime.now())
+	for root, dirs, files in os.walk(".", topdown=True):
+		for file in files:
+			if file.endswith(".wdl"):
+				this_wdl = os.path.join(root, file)
+				print("[%s] Checking %s..." % (datetime.datetime.now(), this_wdl))
+				try:
+					subprocess.check_call(["java", "-jar", "/Applications/womtool-76.jar",
+					 "validate", "%s" % this_wdl], stdout=subprocess.DEVNULL)
+				except subprocess.CalledProcessError as oops:
+					# womtool will print more useful stderr to command line
+					print("ERROR - womtool returned %s" % oops.returncode)
+					_failed_ = True
 
-print("[%s] Finished syntax check." % datetime.datetime.now())
-if _failed_ == True:
-	print("Syntax errors detected. Not running any further tests.")
-	quit()
+	print("[%s] Finished syntax check." % datetime.datetime.now())
+	if _failed_ == True:
+		print("Syntax errors detected. Not running any further tests.")
+		quit()
+
 
 
 print("Checking workflows...")
+
 print("Not checking check_task_outputs, as its inputs are not local...")
 
+this_test = "fuzzycheck"
+tempfile = open("temp.txt", "w")
 print("[%s] Run fuzzycheck via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
@@ -40,21 +45,40 @@ try:
 	 "testRDataarray=test_data/allele_chr2.RData",
 	 "truthRDataarray=test_data/truths/allele_chr1.RData",
 	 "truthRDataarray=test_data/truths/allele_chr2.RData"],
-	 stderr=subprocess.STDOUT)
+	 stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
 
+this_test = "outputs_all_required base case"
+tempfile = open("temp.txt", "w")
 print("[%s] Run outputs_all_required base case via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
 	"file1=test_data/allele_chr1.RData",
 	"file2=test_data/truths/allele_chr1.RData",
-	"file3=test_data/allele_chr1.RData"])
+	"file3=test_data/allele_chr1.RData"],
+	stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
 
+this_test = "outputs_all_required checker case"
+tempfile = open("temp.txt", "w")
 print("[%s] Run outputs_all_required checker case via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
@@ -63,20 +87,40 @@ try:
 	"file3=test_data/NWD119836.0005.recab.crai",
 	"singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt",
 	"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
-	"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"])
+	"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"],
+	stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
 
+this_test = "outputs_some_optional base case"
+tempfile = open("temp.txt", "w")
 print("[%s] Run outputs_some_optional base case via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
 	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
-	"requiredInput=test_data/NWD176325.005percent.recab.crai"])
+	"requiredInput=test_data/NWD176325.005percent.recab.crai"],
+	stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
 
+this_test = "outputs_some_optional checker case"
+tempfile = open("temp.txt", "w")
 print("[%s] Run outputs_some_optional checker case via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
@@ -85,11 +129,31 @@ try:
 	"singleTruth=test_data/truths/foo.txt",
 	"arrayTruth=test_data/truths/bar.txt",
 	"arrayTruth=test_data/truths/second_bar/bar.txt",
-	"arrayTruth=test_data/truths/foo.txt"])
+	"arrayTruth=test_data/truths/foo.txt"],
+	stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
+
+if _failed_:
+	print("At least one workflow failed.")
 
 # clean up miniwdl leftovers
-today = "".join[datetime.datetime.now().year, datetime.datetime.now().month, datetime.datetime.now().day]
-print(today)
+print("Cleaning up...")
+month_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%m")
+day_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%d")
+today = "".join([str(datetime.datetime.now().year), month_with_zero, day_with_zero])
+if os.path.basename(os.getcwd()) != "checker-WDL-templates":
+	print("You don't seem to be in the expected directory. Just in case, miniwdl files will not be cleaned up.")
+else:
+	os.system("rm -rf %s*" % today)
+
+
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,6 +5,7 @@ import datetime
 import sys
 import os
 
+
 _failed_ = False
 
 print("[%s] Check syntax via womtool..." % datetime.datetime.now())
@@ -26,3 +27,69 @@ if _failed_ == True:
 	print("Syntax errors detected. Not running any further tests.")
 	quit()
 
+
+print("Checking workflows...")
+print("Not checking check_task_outputs, as its inputs are not local...")
+
+print("[%s] Run fuzzycheck via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
+	 "testRDatafile=test_data/allele_chr1.RData",
+	 "truthRDatafile=test_data/truths/allele_chr1.RData",
+	 "testRDataarray=test_data/allele_chr1.RData",
+	 "testRDataarray=test_data/allele_chr2.RData",
+	 "truthRDataarray=test_data/truths/allele_chr1.RData",
+	 "truthRDataarray=test_data/truths/allele_chr2.RData"],
+	 stderr=subprocess.STDOUT)
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+print("[%s] Run outputs_all_required base case via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
+	"file1=test_data/allele_chr1.RData",
+	"file2=test_data/truths/allele_chr1.RData",
+	"file3=test_data/allele_chr1.RData"])
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+print("[%s] Run outputs_all_required checker case via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
+	"file1=test_data/NWD176325.005percent.recab.crai",
+	"file2=test_data/NWD119836.0005.recab.cram.crai",
+	"file3=test_data/NWD119836.0005.recab.crai",
+	"singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt",
+	"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
+	"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"])
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+print("[%s] Run outputs_some_optional base case via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
+	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
+	"requiredInput=test_data/NWD176325.005percent.recab.crai"])
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+print("[%s] Run outputs_some_optional checker case via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
+	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
+	"requiredInput=test_data/NWD176325.005percent.recab.crai",
+	"singleTruth=test_data/truths/foo.txt",
+	"arrayTruth=test_data/truths/bar.txt",
+	"arrayTruth=test_data/truths/second_bar/bar.txt",
+	"arrayTruth=test_data/truths/foo.txt"])
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+# clean up miniwdl leftovers
+today = "".join[datetime.datetime.now().year, datetime.datetime.now().month, datetime.datetime.now().day]
+print(today)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,7 @@
+import subprocess
+import sys
+
+thing = subprocess.run(["./tests/tests.sh"])
+
+print(thing.stdout)
+print(thing.stderr)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,28 @@
+# Meant to be run from the root directory of the repo.
+
 import subprocess
+import datetime
 import sys
+import os
 
-thing = subprocess.run(["./tests/tests.sh"])
+_failed_ = False
 
-print(thing.stdout)
-print(thing.stderr)
+print("[%s] Check syntax via womtool..." % datetime.datetime.now())
+for root, dirs, files in os.walk(".", topdown=True):
+	for file in files:
+		if file.endswith(".wdl"):
+			this_wdl = os.path.join(root, file)
+			print("[%s] Checking %s..." % (datetime.datetime.now(), this_wdl))
+			try:
+				subprocess.check_call(["java", "-jar", "/Applications/womtool-76.jar",
+				 "validate", "%s" % this_wdl], stdout=subprocess.DEVNULL)
+			except subprocess.CalledProcessError as oops:
+				# womtool will print more useful stderr to command line
+				print("ERROR - womtool returned %s" % oops.returncode)
+				_failed_ = True
+
+print("[%s] Finished syntax check." % datetime.datetime.now())
+if _failed_ == True:
+	print("Syntax errors detected. Not running any further tests.")
+	quit()
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,24 @@ import os
 skip_syntax_check = True # just for debugging
 _failed_ = False
 
-if not skip_syntax_check:
+def check_workflow(wf_name, subprocess_array):
+	tempfile = open("temp.txt", "w")
+	print("[%s] Run %s via miniwdl" % (datetime.datetime.now(), wf_name))
+	try:
+		subprocess.check_call(subprocess_array,
+		stdout=subprocess.DEVNULL, stderr=tempfile)
+	except subprocess.CalledProcessError as oops:
+		tempfile.close()
+		print("ERROR - womtool returned %s" % oops.returncode)
+		with open("miniwdl_errors.txt", "a") as stderrfile:
+			stderrfile.write("----- Error in %s ------" % this_test)
+			with open("temp.txt", "r") as captured_output:
+				for line in captured_output:
+					stderrfile.write(line)
+		_failed_ = True
+	tempfile.close()
+
+def syntax_check():
 	print("[%s] Check syntax via womtool..." % datetime.datetime.now())
 	for root, dirs, files in os.walk(".", topdown=True):
 		for file in files:
@@ -28,132 +45,66 @@ if not skip_syntax_check:
 		print("Syntax errors detected. Not running any further tests.")
 		quit()
 
+def cleanup_miniwdl_extras():
+	print("Cleaning up...")
+	month_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%m")
+	day_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%d")
+	today = "".join([str(datetime.datetime.now().year), month_with_zero, day_with_zero])
+	if os.path.basename(os.getcwd()) != "checker-WDL-templates":
+		print("You don't seem to be in the expected directory. Just in case, miniwdl files will not be cleaned up.")
+	else:
+		os.system("rm -rf %s*" % today)
+
+def main():
+	if not skip_syntax_check:
+		syntax_check()
+	print("Checking workflows...")
+	print("Not checking check_task_outputs, as its inputs are not local...")
+
+	check_workflow("fuzzycheck", ["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
+		 "testRDatafile=test_data/allele_chr1.RData",
+		 "truthRDatafile=test_data/truths/allele_chr1.RData",
+		 "testRDataarray=test_data/allele_chr1.RData",
+		 "testRDataarray=test_data/allele_chr2.RData",
+		 "truthRDataarray=test_data/truths/allele_chr1.RData",
+		 "truthRDataarray=test_data/truths/allele_chr2.RData"])
+
+	check_workflow("outputs_all_required base case", 
+		["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
+		"file1=test_data/allele_chr1.RData",
+		"file2=test_data/truths/allele_chr1.RData",
+		"file3=test_data/allele_chr1.RData"])
+
+	check_workflow("outputs_all_required checker case",
+		["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
+		"file1=test_data/NWD176325.005percent.recab.crai",
+		"file2=test_data/NWD119836.0005.recab.cram.crai",
+		"file3=test_data/NWD119836.0005.recab.crai",
+		"singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt",
+		"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
+		"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"])
 
 
-print("Checking workflows...")
+	check_workflow("outputs_some_optional base case",
+		["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
+		"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
+		"requiredInput=test_data/NWD176325.005percent.recab.crai"])
 
-print("Not checking check_task_outputs, as its inputs are not local...")
+	check_workflow("outputs_some_optional checker case",
+		["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
+		"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
+		"requiredInput=test_data/NWD176325.005percent.recab.crai",
+		"singleTruth=test_data/truths/foo.txt",
+		"arrayTruth=test_data/truths/bar.txt",
+		"arrayTruth=test_data/truths/second_bar/bar.txt",
+		"arrayTruth=test_data/truths/foo.txt"])
 
-this_test = "fuzzycheck"
-tempfile = open("temp.txt", "w")
-print("[%s] Run fuzzycheck via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
-	 "testRDatafile=test_data/allele_chr1.RData",
-	 "truthRDatafile=test_data/truths/allele_chr1.RData",
-	 "testRDataarray=test_data/allele_chr1.RData",
-	 "testRDataarray=test_data/allele_chr2.RData",
-	 "truthRDataarray=test_data/truths/allele_chr1.RData",
-	 "truthRDataarray=test_data/truths/allele_chr2.RData"],
-	 stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
+	if _failed_:
+		print("At least one workflow failed.")
 
-this_test = "outputs_all_required base case"
-tempfile = open("temp.txt", "w")
-print("[%s] Run outputs_all_required base case via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
-	"file1=test_data/allele_chr1.RData",
-	"file2=test_data/truths/allele_chr1.RData",
-	"file3=test_data/allele_chr1.RData"],
-	stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
+	cleanup_miniwdl_extras()
 
-this_test = "outputs_all_required checker case"
-tempfile = open("temp.txt", "w")
-print("[%s] Run outputs_all_required checker case via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
-	"file1=test_data/NWD176325.005percent.recab.crai",
-	"file2=test_data/NWD119836.0005.recab.cram.crai",
-	"file3=test_data/NWD119836.0005.recab.crai",
-	"singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt",
-	"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
-	"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"],
-	stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
-
-this_test = "outputs_some_optional base case"
-tempfile = open("temp.txt", "w")
-print("[%s] Run outputs_some_optional base case via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
-	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
-	"requiredInput=test_data/NWD176325.005percent.recab.crai"],
-	stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
-
-this_test = "outputs_some_optional checker case"
-tempfile = open("temp.txt", "w")
-print("[%s] Run outputs_some_optional checker case via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
-	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
-	"requiredInput=test_data/NWD176325.005percent.recab.crai",
-	"singleTruth=test_data/truths/foo.txt",
-	"arrayTruth=test_data/truths/bar.txt",
-	"arrayTruth=test_data/truths/second_bar/bar.txt",
-	"arrayTruth=test_data/truths/foo.txt"],
-	stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
-
-if _failed_:
-	print("At least one workflow failed.")
-
-# clean up miniwdl leftovers
-print("Cleaning up...")
-month_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%m")
-day_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%d")
-today = "".join([str(datetime.datetime.now().year), month_with_zero, day_with_zero])
-if os.path.basename(os.getcwd()) != "checker-WDL-templates":
-	print("You don't seem to be in the expected directory. Just in case, miniwdl files will not be cleaned up.")
-else:
-	os.system("rm -rf %s*" % today)
-
+if __name__ == "__main__":
+	main()
 
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Using womtool to check the syntax as that is what Terra relies on
+# Using miniwdl to actually run the workflows as it is less verbose 
+
+echo "$(date +["%r %m-%d-%y"]) Beginning test of checker workflow templates" > output.txt
+
+echo "Checking syntax..."
+echo "$(date +["%r %m-%d-%y"]) Check syntax via womtool" >> output.txt
+for file in $(find checker_tasks/ check_task_outputs/ check_wf_outputs/ check_approximately_equals/ -name '*.wdl' -type f -print);
+do
+	echo ${file} >> output.txt
+	java -jar /Applications/womtool-76.jar validate ${file} >> output.txt
+done
+
+
+echo "Checking workflows..."
+
+echo "$(date +["%r %m-%d-%y"]) Run fuzzycheck via miniwdl" >> output.txt
+miniwdl run check_approximately_equals/fuzzycheck_RData.wdl \
+	testRDatafile=test_data/allele_chr1.RData \
+	truthRDatafile=test_data/truths/allele_chr1.RData \
+	testRDataarray=test_data/allele_chr1.RData \
+	testRDataarray=test_data/allele_chr2.RData \
+	truthRDataarray=test_data/truths/allele_chr1.RData \
+	truthRDataarray=test_data/truths/allele_chr2.RData
+
+echo "$(date +["%r %m-%d-%y"]) Not checking check_task_outputs, as its inputs are not local..." >> output.txt
+
+echo "$(date +["%r %m-%d-%y"]) Run outputs_all_required base case via miniwdl" >> output.txt
+miniwdl run check_wf_outputs/outputs_all_required/parent_req.wdl \
+	file1=test_data/allele_chr1.RData \
+	file2=test_data/truths/allele_chr1.RData \
+	file3=test_data/allele_chr1.RData 
+
+echo "$(date +["%r %m-%d-%y"]) Run outputs_all_required checker case via miniwdl" >> output.txt
+miniwdl run check_wf_outputs/outputs_all_required/template_req.wdl \
+	file1=test_data/NWD176325.005percent.recab.crai \
+	file2=test_data/NWD119836.0005.recab.cram.crai \
+	file3=test_data/NWD119836.0005.recab.crai \
+	singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt \
+	truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt \
+	truthSet=test_data/truths/NWD119836.0005.recab.crai.txt
+
+
+

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,7 +1,32 @@
 #!/bin/bash
 
-# Using womtool to check the syntax as that is what Terra relies on
-# Using miniwdl to actually run the workflows as it is less verbose 
+# ███████████████████████████████████ LICENSE ██████████████████████████████████
+# Copyright 2022 Aisling "Ash" O'Farrell
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ███████████████████████████████████ NOTES ████████████████████████████████████
+# Purpose: This is a simple sh file that makes sure I do not break my templates.
+#          It is not designed to be a learning resource, but it is relatively
+#          simple and you can base your own tests upon it (per the rules of the
+#          above license). The first step is to check the syntax of all .wdls in
+#          the repository with womtool, which is the same syntax verification
+#          used by Cromwell (which is used by Terra). Actual testing of relevent
+#          workflows is done with miniwdl, as miniwdl is faster than Cromwell
+#          and has much less verbose output.
+#
+# Requirements: * Python 3.7 or higher (to run miniwdl)
+#               * Java (to run womtool)
+#               * miniwdl: https://github.com/chanzuckerberg/miniwdl
+#               * womtool: https://github.com/broadinstitute/cromwell  
+# 
 
 echo "$(date +["%r %m-%d-%y"]) Beginning test of checker workflow templates" > output.txt
 
@@ -42,5 +67,18 @@ miniwdl run check_wf_outputs/outputs_all_required/template_req.wdl \
 	truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt \
 	truthSet=test_data/truths/NWD119836.0005.recab.crai.txt
 
+echo "$(date +["%r %m-%d-%y"]) Run outputs_some_optional base case via miniwdl" >> output.txt
+miniwdl run check_wf_outputs/outputs_some_optional/parent_opt.wdl \
+	optionalInput=test_data/NWD119836.0005.recab.cram.crai \
+	requiredInput=test_data/NWD176325.005percent.recab.crai 
+
+echo "$(date +["%r %m-%d-%y"]) Run outputs_some_optional checker case via miniwdl" >> output.txt
+miniwdl run check_wf_outputs/outputs_some_optional/template_opt.wdl \
+	optionalInput=test_data/NWD119836.0005.recab.cram.crai \
+	requiredInput=test_data/NWD176325.005percent.recab.crai \
+	singleTruth=test_data/truths/foo.txt \
+	arrayTruth=test_data/truths/bar.txt \
+	arrayTruth=test_data/truths/second_bar/bar.txt \
+	arrayTruth=test_data/truths/foo.txt 
 
 


### PR DESCRIPTION
Adds very simple automated testing to make sure my workflows do not catastrophically break. This should help me overhaul this workspace without breaking too much as I go along. Tests will be added/subtracted manually as needed. (Eventually I intend on reducing the number of WDLs in this repo, so the manual nature of adding/removing tests is okay with me for the time being.)

Limitations:
* This is not part of circleci as we would need a Dockstore admin to enable circleci in this repo
* miniwdl seems to keep getting certificate errors when calling GitHub (Cromwell does not have this issue) so I made the decision to switch all of the WDLs to use local imports by default -- this makes them slightly less "plug and play" but is arguably better practice anyway (and helped me realize some of the local paths were outdated)
* One workflow gets skipped because it is a mirror of the null model workflow in analysis_pipeline_wdl and would need far too much test data to be mirrored in this repo
* The usefulness of output.txt is debatable as I am not piping miniwdl's output to it, as I think the command line view of miniwdl is easier to parse then what you get in a text file