### PR TITLE
Add stringcheck task

### DIFF
--- a/checker_tasks/stringcheck_task.wdl
+++ b/checker_tasks/stringcheck_task.wdl
@@ -27,6 +27,7 @@ task stringcheck {
             echo "true" > result.txt
         else
             echo "false" > result.txt
+            exit 1
         fi
     >>>
 

--- a/checker_tasks/stringcheck_task.wdl
+++ b/checker_tasks/stringcheck_task.wdl
@@ -1,0 +1,42 @@
+version 1.0
+
+################################## LICENSE ##################################
+# Copyright 2026 Aisling "Ash" O'Farrell
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+task stringcheck {
+    input {
+        String truth
+        String test
+    }
+
+    command <<<
+        set -euo pipefail
+
+        # Strict string comparison in Bash
+        if [ "~{truth}" = "~{test}" ]
+        then
+            echo "true" > result.txt
+        else
+            echo "false" > result.txt
+        fi
+    >>>
+
+    output {
+        Boolean is_equal = read_boolean("result.txt")
+    }
+
+    runtime {
+        docker: "ubuntu:latest"
+        cpu: 1
+        memory: "1 GiB"
+    }
+}


### PR DESCRIPTION
This task adds a new type of checker, comparing a WDL String with another WDL String. Both strings must be defined. Fuzzy matches are not supported.

This is currently used in [myco's checker](https://github.com/aofarrel/myco/blob/main/checker.wdl) for samples that are QC failures. Every sample that goes through myco generates a string, either "PASS" or a reason why it failed. The reason why it failed includes specific QC measurements, such as calculated coverage, so this is useful for checking that QC metrics are being measured in the same way every time.

For example, myco imports Theiagen's fork of TBProfiler. It calculates mean coverage (TBProfiler normally only calculates median coverage). Recently, Theiagen's fork has changed how it calculates that mean coverage, so the samples that are known to fail due to failing coverage were (correctly) detected flagged as returning different strings in their status string.