### PR TITLE
Add tests... but better!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ Cromwell.stderr.txt
 Cromwell.stdout.txt
 .DS_Store
 */cromwell-input/*
+output.txt
+*_checker/*
+_LAST
+*_wf/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ output.txt
 *_checker/*
 _LAST
 *_wf/*
+temp.txt

--- a/check_approximately_equals/fuzzycheck_RData.wdl
+++ b/check_approximately_equals/fuzzycheck_RData.wdl
@@ -52,7 +52,6 @@ workflow checker {
 		input:
 			test = testRDataarray,
 			truth = truthRDataarray,
-			truth = truthRDataarray,
 			rdata_check = true
 	}
 

--- a/check_approximately_equals/fuzzycheck_RData.wdl
+++ b/check_approximately_equals/fuzzycheck_RData.wdl
@@ -13,20 +13,20 @@ version 1.0
 # limitations under the License.
 
 ################################### NOTES ####################################
-# If running this locally, you can import tasks with relative paths, like this:
-#import "example_req.wdl" as check_me
-#import "../tasks/filecheck_task.wdl" as verify_file
-#import "../tasks/arraycheck_task.wdl" as verify_array
 #
 # There is no functional difference between "here's an array of files from
 # multiple different tasks" and "here's an array of files that was output 
 # from a single task," provided that in both cases ALL files within the array
 # AND the array itself are NOT optional. You do not need to know how many
 # files are in an array, but none of those files can have type File?.
+#
+# If running this locally, you can import tasks with relative paths, like this:
+import "../checker_tasks/filecheck_task.wdl" as verify_file
+import "../checker_tasks/arraycheck_task.wdl" as verify_array
 
 # Replace the first URL here with the URL of the workflow to be checked.
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
 
 
 workflow checker {

--- a/check_approximately_equals/fuzzycheck_RData.wdl
+++ b/check_approximately_equals/fuzzycheck_RData.wdl
@@ -52,6 +52,7 @@ workflow checker {
 		input:
 			test = testRDataarray,
 			truth = truthRDataarray,
+			truth = truthRDataarray,
 			rdata_check = true
 	}
 

--- a/check_wf_outputs/outputs_all_required/template_req.wdl
+++ b/check_wf_outputs/outputs_all_required/template_req.wdl
@@ -13,10 +13,6 @@ version 1.0
 # limitations under the License.
 
 ################################### NOTES ####################################
-# If running this locally, you can import tasks with relative paths, like this:
-#import "example_req.wdl" as check_me
-#import "../tasks/filecheck_task.wdl" as verify_file
-#import "../tasks/arraycheck_task.wdl" as verify_array
 #
 # There is no functional difference between "here's an array of files from
 # multiple different tasks" and "here's an array of files that was output 
@@ -25,9 +21,14 @@ version 1.0
 # files are in an array, but none of those files can have type File?.
 
 # Replace the first URL here with the URL of the workflow to be checked.
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/check_wf_outputs/outputs_all_required/parent_req.wdl" as check_me
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/check_wf_outputs/outputs_all_required/parent_req.wdl" as check_me
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
+
+# If running this locally, you can import tasks with relative paths, like this:
+import "parent_req.wdl" as check_me
+import "../../checker_tasks/filecheck_task.wdl" as verify_file
+import "../../checker_tasks/arraycheck_task.wdl" as verify_array
 
 workflow checker {
 	input {

--- a/check_wf_outputs/outputs_some_optional/template_opt.wdl
+++ b/check_wf_outputs/outputs_some_optional/template_opt.wdl
@@ -11,16 +11,6 @@ version 1.0
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Replace the first URL here with the URL of the workflow to be checked.
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/check_wf_outputs/outputs_some_optional/parent_opt.wdl" as check_me
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
-
-# If running this locally, you can import tasks with relative paths, like this:
-#import "parent_opt.wdl" as check_me
-#import "../../checker_tasks/filecheck_task.wdl" as verify_file
-#import "../../checker_tasks/arraycheck_task.wdl" as verify_array
-
 # In summary:
 # Workflow outputs single Array[File] --> call arraycheck_classic
 # Workflow outputs several Files, all of which are required --> call arraycheck_classic
@@ -28,6 +18,16 @@ import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0
 # Workflow outputs several Files, some of which are required --> call arraycheck_classic with select_first()
 # Workflow outputs single File, which is required --> call filecheck
 # Workflow outputs optional File --> call filecheck but put in a defined() check before the task call or use select_first()
+
+# Replace the first URL here with the URL of the workflow to be checked.
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/check_wf_outputs/outputs_some_optional/parent_opt.wdl" as check_me
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/filecheck_task.wdl" as verify_file
+#import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
+
+# If running this locally, you can import tasks with relative paths, like this:
+import "parent_opt.wdl" as check_me
+import "../../checker_tasks/filecheck_task.wdl" as verify_file
+import "../../checker_tasks/arraycheck_task.wdl" as verify_array
 
 
 workflow checker {

--- a/checker_tasks/arraycheck_task.wdl
+++ b/checker_tasks/arraycheck_task.wdl
@@ -26,7 +26,7 @@ task arraycheck_classic {
 		Array[File] test
 		Array[File] truth
 		Boolean fastfail = false  # should we exit out upon first mismatch?
-		Boolean rdata_check = false  # check with all.equal() upon failure; only use with RData files!
+		Boolean rdata_check = false  # check with all.equal() fdupon failure; only use with RData files!
 		Float tolerance = 0.00000001  # tolerance to use for all.equal(); default is 1.0E-8
 	}
 

--- a/checker_tasks/arraycheck_task.wdl
+++ b/checker_tasks/arraycheck_task.wdl
@@ -26,7 +26,7 @@ task arraycheck_classic {
 		Array[File] test
 		Array[File] truth
 		Boolean fastfail = false  # should we exit out upon first mismatch?
-		Boolean rdata_check = false  # check with all.equal() fdupon failure; only use with RData files!
+		Boolean rdata_check = false  # check with all.equal() upon failure; only use with RData files!
 		Float tolerance = 0.00000001  # tolerance to use for all.equal(); default is 1.0E-8
 	}
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,32 +5,37 @@ import datetime
 import sys
 import os
 
-
+skip_syntax_check = True # just for debugging
 _failed_ = False
 
-print("[%s] Check syntax via womtool..." % datetime.datetime.now())
-for root, dirs, files in os.walk(".", topdown=True):
-	for file in files:
-		if file.endswith(".wdl"):
-			this_wdl = os.path.join(root, file)
-			print("[%s] Checking %s..." % (datetime.datetime.now(), this_wdl))
-			try:
-				subprocess.check_call(["java", "-jar", "/Applications/womtool-76.jar",
-				 "validate", "%s" % this_wdl], stdout=subprocess.DEVNULL)
-			except subprocess.CalledProcessError as oops:
-				# womtool will print more useful stderr to command line
-				print("ERROR - womtool returned %s" % oops.returncode)
-				_failed_ = True
+if not skip_syntax_check:
+	print("[%s] Check syntax via womtool..." % datetime.datetime.now())
+	for root, dirs, files in os.walk(".", topdown=True):
+		for file in files:
+			if file.endswith(".wdl"):
+				this_wdl = os.path.join(root, file)
+				print("[%s] Checking %s..." % (datetime.datetime.now(), this_wdl))
+				try:
+					subprocess.check_call(["java", "-jar", "/Applications/womtool-76.jar",
+					 "validate", "%s" % this_wdl], stdout=subprocess.DEVNULL)
+				except subprocess.CalledProcessError as oops:
+					# womtool will print more useful stderr to command line
+					print("ERROR - womtool returned %s" % oops.returncode)
+					_failed_ = True
 
-print("[%s] Finished syntax check." % datetime.datetime.now())
-if _failed_ == True:
-	print("Syntax errors detected. Not running any further tests.")
-	quit()
+	print("[%s] Finished syntax check." % datetime.datetime.now())
+	if _failed_ == True:
+		print("Syntax errors detected. Not running any further tests.")
+		quit()
+
 
 
 print("Checking workflows...")
+
 print("Not checking check_task_outputs, as its inputs are not local...")
 
+this_test = "fuzzycheck"
+tempfile = open("temp.txt", "w")
 print("[%s] Run fuzzycheck via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
@@ -40,21 +45,40 @@ try:
 	 "testRDataarray=test_data/allele_chr2.RData",
 	 "truthRDataarray=test_data/truths/allele_chr1.RData",
 	 "truthRDataarray=test_data/truths/allele_chr2.RData"],
-	 stderr=subprocess.STDOUT)
+	 stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
 
+this_test = "outputs_all_required base case"
+tempfile = open("temp.txt", "w")
 print("[%s] Run outputs_all_required base case via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
 	"file1=test_data/allele_chr1.RData",
 	"file2=test_data/truths/allele_chr1.RData",
-	"file3=test_data/allele_chr1.RData"])
+	"file3=test_data/allele_chr1.RData"],
+	stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
 
+this_test = "outputs_all_required checker case"
+tempfile = open("temp.txt", "w")
 print("[%s] Run outputs_all_required checker case via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
@@ -63,20 +87,40 @@ try:
 	"file3=test_data/NWD119836.0005.recab.crai",
 	"singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt",
 	"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
-	"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"])
+	"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"],
+	stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
 
+this_test = "outputs_some_optional base case"
+tempfile = open("temp.txt", "w")
 print("[%s] Run outputs_some_optional base case via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
 	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
-	"requiredInput=test_data/NWD176325.005percent.recab.crai"])
+	"requiredInput=test_data/NWD176325.005percent.recab.crai"],
+	stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
 
+this_test = "outputs_some_optional checker case"
+tempfile = open("temp.txt", "w")
 print("[%s] Run outputs_some_optional checker case via miniwdl" % datetime.datetime.now())
 try:
 	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
@@ -85,11 +129,31 @@ try:
 	"singleTruth=test_data/truths/foo.txt",
 	"arrayTruth=test_data/truths/bar.txt",
 	"arrayTruth=test_data/truths/second_bar/bar.txt",
-	"arrayTruth=test_data/truths/foo.txt"])
+	"arrayTruth=test_data/truths/foo.txt"],
+	stdout=subprocess.DEVNULL, stderr=tempfile)
 except subprocess.CalledProcessError as oops:
+	tempfile.close()
 	print("ERROR - womtool returned %s" % oops.returncode)
+	with open("miniwdl_errors.txt", "a") as stderrfile:
+		stderrfile.write("----- Error in %s ------" % this_test)
+		with open("temp.txt", "r") as captured_output:
+			for line in captured_output:
+				stderrfile.write(line)
 	_failed_ = True
+tempfile.close()
+
+if _failed_:
+	print("At least one workflow failed.")
 
 # clean up miniwdl leftovers
-today = "".join[datetime.datetime.now().year, datetime.datetime.now().month, datetime.datetime.now().day]
-print(today)
+print("Cleaning up...")
+month_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%m")
+day_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%d")
+today = "".join([str(datetime.datetime.now().year), month_with_zero, day_with_zero])
+if os.path.basename(os.getcwd()) != "checker-WDL-templates":
+	print("You don't seem to be in the expected directory. Just in case, miniwdl files will not be cleaned up.")
+else:
+	os.system("rm -rf %s*" % today)
+
+
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,6 +5,7 @@ import datetime
 import sys
 import os
 
+
 _failed_ = False
 
 print("[%s] Check syntax via womtool..." % datetime.datetime.now())
@@ -26,3 +27,69 @@ if _failed_ == True:
 	print("Syntax errors detected. Not running any further tests.")
 	quit()
 
+
+print("Checking workflows...")
+print("Not checking check_task_outputs, as its inputs are not local...")
+
+print("[%s] Run fuzzycheck via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
+	 "testRDatafile=test_data/allele_chr1.RData",
+	 "truthRDatafile=test_data/truths/allele_chr1.RData",
+	 "testRDataarray=test_data/allele_chr1.RData",
+	 "testRDataarray=test_data/allele_chr2.RData",
+	 "truthRDataarray=test_data/truths/allele_chr1.RData",
+	 "truthRDataarray=test_data/truths/allele_chr2.RData"],
+	 stderr=subprocess.STDOUT)
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+print("[%s] Run outputs_all_required base case via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
+	"file1=test_data/allele_chr1.RData",
+	"file2=test_data/truths/allele_chr1.RData",
+	"file3=test_data/allele_chr1.RData"])
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+print("[%s] Run outputs_all_required checker case via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
+	"file1=test_data/NWD176325.005percent.recab.crai",
+	"file2=test_data/NWD119836.0005.recab.cram.crai",
+	"file3=test_data/NWD119836.0005.recab.crai",
+	"singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt",
+	"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
+	"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"])
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+print("[%s] Run outputs_some_optional base case via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
+	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
+	"requiredInput=test_data/NWD176325.005percent.recab.crai"])
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+print("[%s] Run outputs_some_optional checker case via miniwdl" % datetime.datetime.now())
+try:
+	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
+	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
+	"requiredInput=test_data/NWD176325.005percent.recab.crai",
+	"singleTruth=test_data/truths/foo.txt",
+	"arrayTruth=test_data/truths/bar.txt",
+	"arrayTruth=test_data/truths/second_bar/bar.txt",
+	"arrayTruth=test_data/truths/foo.txt"])
+except subprocess.CalledProcessError as oops:
+	print("ERROR - womtool returned %s" % oops.returncode)
+	_failed_ = True
+
+# clean up miniwdl leftovers
+today = "".join[datetime.datetime.now().year, datetime.datetime.now().month, datetime.datetime.now().day]
+print(today)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,7 @@
+import subprocess
+import sys
+
+thing = subprocess.run(["./tests/tests.sh"])
+
+print(thing.stdout)
+print(thing.stderr)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,28 @@
+# Meant to be run from the root directory of the repo.
+
 import subprocess
+import datetime
 import sys
+import os
 
-thing = subprocess.run(["./tests/tests.sh"])
+_failed_ = False
 
-print(thing.stdout)
-print(thing.stderr)
+print("[%s] Check syntax via womtool..." % datetime.datetime.now())
+for root, dirs, files in os.walk(".", topdown=True):
+	for file in files:
+		if file.endswith(".wdl"):
+			this_wdl = os.path.join(root, file)
+			print("[%s] Checking %s..." % (datetime.datetime.now(), this_wdl))
+			try:
+				subprocess.check_call(["java", "-jar", "/Applications/womtool-76.jar",
+				 "validate", "%s" % this_wdl], stdout=subprocess.DEVNULL)
+			except subprocess.CalledProcessError as oops:
+				# womtool will print more useful stderr to command line
+				print("ERROR - womtool returned %s" % oops.returncode)
+				_failed_ = True
+
+print("[%s] Finished syntax check." % datetime.datetime.now())
+if _failed_ == True:
+	print("Syntax errors detected. Not running any further tests.")
+	quit()
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,24 @@ import os
 skip_syntax_check = True # just for debugging
 _failed_ = False
 
-if not skip_syntax_check:
+def check_workflow(wf_name, subprocess_array):
+	tempfile = open("temp.txt", "w")
+	print("[%s] Run %s via miniwdl" % (datetime.datetime.now(), wf_name))
+	try:
+		subprocess.check_call(subprocess_array,
+		stdout=subprocess.DEVNULL, stderr=tempfile)
+	except subprocess.CalledProcessError as oops:
+		tempfile.close()
+		print("ERROR - womtool returned %s" % oops.returncode)
+		with open("miniwdl_errors.txt", "a") as stderrfile:
+			stderrfile.write("----- Error in %s ------" % this_test)
+			with open("temp.txt", "r") as captured_output:
+				for line in captured_output:
+					stderrfile.write(line)
+		_failed_ = True
+	tempfile.close()
+
+def syntax_check():
 	print("[%s] Check syntax via womtool..." % datetime.datetime.now())
 	for root, dirs, files in os.walk(".", topdown=True):
 		for file in files:
@@ -28,132 +45,66 @@ if not skip_syntax_check:
 		print("Syntax errors detected. Not running any further tests.")
 		quit()
 
+def cleanup_miniwdl_extras():
+	print("Cleaning up...")
+	month_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%m")
+	day_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%d")
+	today = "".join([str(datetime.datetime.now().year), month_with_zero, day_with_zero])
+	if os.path.basename(os.getcwd()) != "checker-WDL-templates":
+		print("You don't seem to be in the expected directory. Just in case, miniwdl files will not be cleaned up.")
+	else:
+		os.system("rm -rf %s*" % today)
+
+def main():
+	if not skip_syntax_check:
+		syntax_check()
+	print("Checking workflows...")
+	print("Not checking check_task_outputs, as its inputs are not local...")
+
+	check_workflow("fuzzycheck", ["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
+		 "testRDatafile=test_data/allele_chr1.RData",
+		 "truthRDatafile=test_data/truths/allele_chr1.RData",
+		 "testRDataarray=test_data/allele_chr1.RData",
+		 "testRDataarray=test_data/allele_chr2.RData",
+		 "truthRDataarray=test_data/truths/allele_chr1.RData",
+		 "truthRDataarray=test_data/truths/allele_chr2.RData"])
+
+	check_workflow("outputs_all_required base case", 
+		["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
+		"file1=test_data/allele_chr1.RData",
+		"file2=test_data/truths/allele_chr1.RData",
+		"file3=test_data/allele_chr1.RData"])
+
+	check_workflow("outputs_all_required checker case",
+		["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
+		"file1=test_data/NWD176325.005percent.recab.crai",
+		"file2=test_data/NWD119836.0005.recab.cram.crai",
+		"file3=test_data/NWD119836.0005.recab.crai",
+		"singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt",
+		"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
+		"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"])
 
 
-print("Checking workflows...")
+	check_workflow("outputs_some_optional base case",
+		["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
+		"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
+		"requiredInput=test_data/NWD176325.005percent.recab.crai"])
 
-print("Not checking check_task_outputs, as its inputs are not local...")
+	check_workflow("outputs_some_optional checker case",
+		["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
+		"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
+		"requiredInput=test_data/NWD176325.005percent.recab.crai",
+		"singleTruth=test_data/truths/foo.txt",
+		"arrayTruth=test_data/truths/bar.txt",
+		"arrayTruth=test_data/truths/second_bar/bar.txt",
+		"arrayTruth=test_data/truths/foo.txt"])
 
-this_test = "fuzzycheck"
-tempfile = open("temp.txt", "w")
-print("[%s] Run fuzzycheck via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
-	 "testRDatafile=test_data/allele_chr1.RData",
-	 "truthRDatafile=test_data/truths/allele_chr1.RData",
-	 "testRDataarray=test_data/allele_chr1.RData",
-	 "testRDataarray=test_data/allele_chr2.RData",
-	 "truthRDataarray=test_data/truths/allele_chr1.RData",
-	 "truthRDataarray=test_data/truths/allele_chr2.RData"],
-	 stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
+	if _failed_:
+		print("At least one workflow failed.")
 
-this_test = "outputs_all_required base case"
-tempfile = open("temp.txt", "w")
-print("[%s] Run outputs_all_required base case via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
-	"file1=test_data/allele_chr1.RData",
-	"file2=test_data/truths/allele_chr1.RData",
-	"file3=test_data/allele_chr1.RData"],
-	stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
+	cleanup_miniwdl_extras()
 
-this_test = "outputs_all_required checker case"
-tempfile = open("temp.txt", "w")
-print("[%s] Run outputs_all_required checker case via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
-	"file1=test_data/NWD176325.005percent.recab.crai",
-	"file2=test_data/NWD119836.0005.recab.cram.crai",
-	"file3=test_data/NWD119836.0005.recab.crai",
-	"singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt",
-	"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
-	"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"],
-	stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
-
-this_test = "outputs_some_optional base case"
-tempfile = open("temp.txt", "w")
-print("[%s] Run outputs_some_optional base case via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
-	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
-	"requiredInput=test_data/NWD176325.005percent.recab.crai"],
-	stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
-
-this_test = "outputs_some_optional checker case"
-tempfile = open("temp.txt", "w")
-print("[%s] Run outputs_some_optional checker case via miniwdl" % datetime.datetime.now())
-try:
-	subprocess.check_call(["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
-	"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
-	"requiredInput=test_data/NWD176325.005percent.recab.crai",
-	"singleTruth=test_data/truths/foo.txt",
-	"arrayTruth=test_data/truths/bar.txt",
-	"arrayTruth=test_data/truths/second_bar/bar.txt",
-	"arrayTruth=test_data/truths/foo.txt"],
-	stdout=subprocess.DEVNULL, stderr=tempfile)
-except subprocess.CalledProcessError as oops:
-	tempfile.close()
-	print("ERROR - womtool returned %s" % oops.returncode)
-	with open("miniwdl_errors.txt", "a") as stderrfile:
-		stderrfile.write("----- Error in %s ------" % this_test)
-		with open("temp.txt", "r") as captured_output:
-			for line in captured_output:
-				stderrfile.write(line)
-	_failed_ = True
-tempfile.close()
-
-if _failed_:
-	print("At least one workflow failed.")
-
-# clean up miniwdl leftovers
-print("Cleaning up...")
-month_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%m")
-day_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%d")
-today = "".join([str(datetime.datetime.now().year), month_with_zero, day_with_zero])
-if os.path.basename(os.getcwd()) != "checker-WDL-templates":
-	print("You don't seem to be in the expected directory. Just in case, miniwdl files will not be cleaned up.")
-else:
-	os.system("rm -rf %s*" % today)
-
+if __name__ == "__main__":
+	main()
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,9 +10,9 @@ import datetime
 import sys
 import os
 
-skip_syntax_check = False
+skip_syntax_check = True
 
-def check_workflow(wf_name, subprocess_array):
+def run_workflow(wf_name, subprocess_array):
 	tempfile = open("temp.txt", "w")
 	print("[%s] Run %s via miniwdl" % (datetime.datetime.now(), wf_name))
 	try:
@@ -27,12 +27,12 @@ def check_workflow(wf_name, subprocess_array):
 				for line in captured_output:
 					stderrfile.write(line)
 		return False
-	return True
 	tempfile.close()
-
+	return True
+	
 def syntax_check(womtool_path: str):
-	assert os.path.isfile(womtool_path), f"User specified womtool is {womtool_path} but there is no file there!"
 	something_failed = False
+	assert os.path.isfile(womtool_path), f"User specified womtool is {womtool_path} but there is no file there!"
 	print("[%s] Checking syntax via womtool and miniwdl..." % datetime.datetime.now())
 	for root, dirs, files in os.walk(".", topdown=True):
 		for file in files:
@@ -86,7 +86,7 @@ def main(womtool_path: str):
 	print("Checking workflows...")
 	print("Not checking check_task_outputs, as its inputs are not local...")
 
-	check_workflow("fuzzycheck", ["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
+	fuzzycheck_passed = run_workflow("fuzzycheck", ["miniwdl", "run", "check_approximately_equals/fuzzycheck_RData.wdl",
 		 "testRDatafile=test_data/allele_chr1.RData",
 		 "truthRDatafile=test_data/truths/allele_chr1.RData",
 		 "testRDataarray=test_data/allele_chr1.RData",
@@ -94,13 +94,13 @@ def main(womtool_path: str):
 		 "truthRDataarray=test_data/truths/allele_chr1.RData",
 		 "truthRDataarray=test_data/truths/allele_chr2.RData"])
 
-	check_workflow("outputs_all_required base case", 
+	required_base_passed = run_workflow("outputs_all_required base case", 
 		["miniwdl", "run", "check_wf_outputs/outputs_all_required/parent_req.wdl",
 		"file1=test_data/allele_chr1.RData",
 		"file2=test_data/truths/allele_chr1.RData",
 		"file3=test_data/allele_chr1.RData"])
 
-	check_workflow("outputs_all_required checker case",
+	required_checker_passed: run_workflow("outputs_all_required checker case",
 		["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
 		"file1=test_data/NWD176325.005percent.recab.crai",
 		"file2=test_data/NWD119836.0005.recab.cram.crai",
@@ -109,13 +109,12 @@ def main(womtool_path: str):
 		"truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt",
 		"truthSet=test_data/truths/NWD119836.0005.recab.crai.txt"])
 
-
-	check_workflow("outputs_some_optional base case",
+	optionalouts_base_passed = run_workflow("outputs_some_optional base case",
 		["miniwdl", "run", "check_wf_outputs/outputs_some_optional/parent_opt.wdl",
 		"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
 		"requiredInput=test_data/NWD176325.005percent.recab.crai"])
 
-	check_workflow("outputs_some_optional checker case",
+	optionalouts_checker_passed = run_workflow("outputs_some_optional checker case",
 		["miniwdl", "run", "check_wf_outputs/outputs_some_optional/template_opt.wdl",
 		"optionalInput=test_data/NWD119836.0005.recab.cram.crai",
 		"requiredInput=test_data/NWD176325.005percent.recab.crai",
@@ -124,8 +123,9 @@ def main(womtool_path: str):
 		"arrayTruth=test_data/truths/second_bar/bar.txt",
 		"arrayTruth=test_data/truths/foo.txt"])
 
-	if _failed_:
+	if set(fuzzycheck_passed, required_base_passed, required_checker_passed, optionalouts_base_passed, optionalouts_checker_passed) != set(True):
 		print("At least one workflow failed.")
+		sys.exit(1)
 
 	cleanup_miniwdl_extras()
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,24 +10,17 @@ import datetime
 import sys
 import os
 
-skip_syntax_check = True
-
 def run_workflow(wf_name, subprocess_array):
-	tempfile = open("temp.txt", "w")
-	print("[%s] Run %s via miniwdl" % (datetime.datetime.now(), wf_name))
-	try:
-		subprocess.check_call(subprocess_array,
-		stdout=subprocess.DEVNULL, stderr=tempfile)
-	except subprocess.CalledProcessError as oops:
-		tempfile.close()
-		print("ERROR - womtool returned %s" % oops.returncode)
+	print("[%s] [%s] Running via miniwdl" % (datetime.datetime.now(), wf_name))
+	result = subprocess.run(subprocess_array,
+		stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+	if result.returncode != 0:
+		print("[%s] [%s] ERROR - miniwdl run returned %s" % (datetime.datetime.now(), wf_name, result.returncode))
 		with open("miniwdl_errors.txt", "a") as stderrfile:
 			stderrfile.write("----- Error in %s ------" % this_test)
-			with open("temp.txt", "r") as captured_output:
-				for line in captured_output:
-					stderrfile.write(line)
+			stderrfile.write(result.stderr)
 		return False
-	tempfile.close()
+	print("[%s] [%s] Passed miniwdl run" % (datetime.datetime.now(), wf_name))
 	return True
 	
 def syntax_check(womtool_path: str):
@@ -41,10 +34,11 @@ def syntax_check(womtool_path: str):
 					something_failed = True
 				if not passes_womtool_validate(os.path.join(root, file), womtool_path):
 					something_failed = True
-	print("[%s] Finished syntax checking all WDLs" % datetime.datetime.now())
 	if something_failed == True:
-		print("At least one WDL failed miniwdl or Cromwell. Not running any further tests.")
-		sys.exit(1)
+		print("[%s] At least one WDL failed miniwdl check or womtool!" % datetime.datetime.now())
+		return False
+	print("[%s] Finished syntax checking all WDLs, all have passed" % datetime.datetime.now())
+	return True
 
 def passes_miniwdl_check(wdl_to_check: str) -> bool:
 	print("[%s] [%s] Checking with miniwdl..." % (datetime.datetime.now(), wdl_to_check))
@@ -70,19 +64,19 @@ def passes_womtool_validate(wdl_to_check: str, womtool_path: str) -> bool:
 	print("[%s] [%s] Passed womtool" % (datetime.datetime.now(), wdl_to_check))
 	return True
 
-def cleanup_miniwdl_extras():
-	print("Cleaning up...")
-	month_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%m")
-	day_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%d")
-	today = "".join([str(datetime.datetime.now().year), month_with_zero, day_with_zero])
-	if os.path.basename(os.getcwd()) != "checker-WDL-templates":
-		print("You don't seem to be in the expected directory. Just in case, miniwdl files will not be cleaned up.")
-	else:
-		os.system("rm -rf %s*" % today)
+# this is just too risky to be default behavior
+#def cleanup_miniwdl_extras():
+#	print("Cleaning up...")
+#	month_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%m")
+#	day_with_zero = datetime.datetime.strftime(datetime.datetime.now(), "%d")
+#	today = "".join([str(datetime.datetime.now().year), month_with_zero, day_with_zero])
+#	if os.path.basename(os.getcwd()) != "checker-WDL-templates":
+#		print("You don't seem to be in the expected directory. Just in case, miniwdl files will not be cleaned up.")
+#	else:
+#		os.system("rm -rf %s*" % today)
 
 def main(womtool_path: str):
-	if not skip_syntax_check:
-		syntax_check(womtool_path)
+	syntaxcheck_passed = syntax_check(womtool_path)
 	print("Checking workflows...")
 	print("Not checking check_task_outputs, as its inputs are not local...")
 
@@ -100,7 +94,7 @@ def main(womtool_path: str):
 		"file2=test_data/truths/allele_chr1.RData",
 		"file3=test_data/allele_chr1.RData"])
 
-	required_checker_passed: run_workflow("outputs_all_required checker case",
+	required_checker_passed = run_workflow("outputs_all_required checker case",
 		["miniwdl", "run", "check_wf_outputs/outputs_all_required/template_req.wdl",
 		"file1=test_data/NWD176325.005percent.recab.crai",
 		"file2=test_data/NWD119836.0005.recab.cram.crai",
@@ -123,11 +117,12 @@ def main(womtool_path: str):
 		"arrayTruth=test_data/truths/second_bar/bar.txt",
 		"arrayTruth=test_data/truths/foo.txt"])
 
-	if set(fuzzycheck_passed, required_base_passed, required_checker_passed, optionalouts_base_passed, optionalouts_checker_passed) != set(True):
-		print("At least one workflow failed.")
+	if set([syntaxcheck_passed, fuzzycheck_passed, required_base_passed, required_checker_passed, 
+		optionalouts_base_passed, optionalouts_checker_passed]) != set([True]):
+		print("At least one workflow failed syntax checking or while running, see above")
 		sys.exit(1)
 
-	cleanup_miniwdl_extras()
+	#cleanup_miniwdl_extras()
 
 if __name__ == "__main__":
 	if len(sys.argv) != 2:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,7 +11,6 @@ import sys
 import os
 
 skip_syntax_check = False
-_failed_ = False
 
 def check_workflow(wf_name, subprocess_array):
 	tempfile = open("temp.txt", "w")
@@ -27,29 +26,49 @@ def check_workflow(wf_name, subprocess_array):
 			with open("temp.txt", "r") as captured_output:
 				for line in captured_output:
 					stderrfile.write(line)
-		_failed_ = True
+		return False
+	return True
 	tempfile.close()
 
 def syntax_check(womtool_path: str):
-	assert os.path.isfile(womtool_path), f"User specified womtool is {womtool_path} but there is no file there"
-	print("[%s] Check syntax via womtool..." % datetime.datetime.now())
+	assert os.path.isfile(womtool_path), f"User specified womtool is {womtool_path} but there is no file there!"
+	something_failed = False
+	print("[%s] Checking syntax via womtool and miniwdl..." % datetime.datetime.now())
 	for root, dirs, files in os.walk(".", topdown=True):
 		for file in files:
 			if file.endswith(".wdl"):
-				this_wdl = os.path.join(root, file)
-				print("[%s] Checking %s..." % (datetime.datetime.now(), this_wdl))
-				try:
-					subprocess.check_call(["java", "-jar", womtool_path,
-					 "validate", "%s" % this_wdl], stdout=subprocess.DEVNULL)
-				except subprocess.CalledProcessError as oops:
-					# womtool will print more useful stderr to command line
-					print("ERROR - womtool returned %s" % oops.returncode)
-					_failed_ = True
+				if not passes_miniwdl_check(os.path.join(root, file)):
+					something_failed = True
+				if not passes_womtool_validate(os.path.join(root, file), womtool_path):
+					something_failed = True
+	print("[%s] Finished syntax checking all WDLs" % datetime.datetime.now())
+	if something_failed == True:
+		print("At least one WDL failed miniwdl or Cromwell. Not running any further tests.")
+		sys.exit(1)
 
-	print("[%s] Finished syntax check." % datetime.datetime.now())
-	if _failed_ == True:
-		print("Syntax errors detected. Not running any further tests.")
-		quit()
+def passes_miniwdl_check(wdl_to_check: str) -> bool:
+	print("[%s] [%s] Checking with miniwdl..." % (datetime.datetime.now(), wdl_to_check))
+	try:
+		subprocess.check_call(["miniwdl", "check", wdl_to_check], stdout=subprocess.DEVNULL)
+	except subprocess.CalledProcessError as oops:
+		print("[%s] [%s] ERROR - miniwdl check returned %s" % 
+			(datetime.datetime.now(), wdl_to_check, oops.returncode))
+		return False
+	print("[%s] [%s] Passed miniwdl" % (datetime.datetime.now(), wdl_to_check))
+	return True
+
+def passes_womtool_validate(wdl_to_check: str, womtool_path: str) -> bool:
+	print("[%s] [%s] Checking with womtool..." % (datetime.datetime.now(), wdl_to_check))
+	try:
+		subprocess.check_call(["java", "-jar", womtool_path,
+		 "validate", wdl_to_check], stdout=subprocess.DEVNULL)
+	except subprocess.CalledProcessError as oops:
+		# womtool will print more useful stderr to command line
+		print("[%s] [%s] ERROR - womtool returned %s" % 
+			(datetime.datetime.now(), wdl_to_check, oops.returncode))
+		return False
+	print("[%s] [%s] Passed womtool" % (datetime.datetime.now(), wdl_to_check))
+	return True
 
 def cleanup_miniwdl_extras():
 	print("Cleaning up...")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,7 +3,9 @@
 # Requirements: * Python 3.7 or higher (to run miniwdl)
 #               * Java (to run womtool)
 #               * miniwdl: https://github.com/chanzuckerberg/miniwdl
-#               * womtool: https://github.com/broadinstitute/cromwell  
+#               * womtool: https://github.com/broadinstitute/cromwell
+
+# pylint: disable=bad-indentation,consider-using-f-string,line-too-long,missing-module-docstring,trailing-whitespace
 
 import subprocess
 import datetime
@@ -11,36 +13,38 @@ import sys
 import os
 
 def run_workflow(wf_name, subprocess_array):
+	"""Runs workflow via miniwdl (instead of Cromwell, because Cromwell is slow locally)"""
 	print("[%s] [%s] Running via miniwdl" % (datetime.datetime.now(), wf_name))
 	result = subprocess.run(subprocess_array,
-		stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+		stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True, check=False)
 	if result.returncode != 0:
 		print("[%s] [%s] ERROR - miniwdl run returned %s" % (datetime.datetime.now(), wf_name, result.returncode))
-		with open("miniwdl_errors.txt", "a") as stderrfile:
-			stderrfile.write("----- Error in %s ------" % this_test)
+		with open("miniwdl_errors.txt", "a", encoding="utf-8") as stderrfile:
+			stderrfile.write("----- Error in %s ------" % wf_name)
 			stderrfile.write(result.stderr)
 		return False
 	print("[%s] [%s] Passed miniwdl run" % (datetime.datetime.now(), wf_name))
 	return True
 	
-def syntax_check(womtool_path: str):
+def syntax_check(womtool_jar: str):
+	"""Run womtool and miniwdl check on every workflow in the repo"""
 	something_failed = False
-	assert os.path.isfile(womtool_path), f"User specified womtool is {womtool_path} but there is no file there!"
 	print("[%s] Checking syntax via womtool and miniwdl..." % datetime.datetime.now())
-	for root, dirs, files in os.walk(".", topdown=True):
+	for root, _, files in os.walk(".", topdown=True):
 		for file in files:
 			if file.endswith(".wdl"):
 				if not passes_miniwdl_check(os.path.join(root, file)):
 					something_failed = True
-				if not passes_womtool_validate(os.path.join(root, file), womtool_path):
+				if not passes_womtool_validate(os.path.join(root, file), womtool_jar):
 					something_failed = True
-	if something_failed == True:
+	if something_failed is True:
 		print("[%s] At least one WDL failed miniwdl check or womtool!" % datetime.datetime.now())
 		return False
 	print("[%s] Finished syntax checking all WDLs, all have passed" % datetime.datetime.now())
 	return True
 
 def passes_miniwdl_check(wdl_to_check: str) -> bool:
+	"""Does `miniwdl check wdl_to_check` return 0? (WARNINGS WILL NOT BE SHOWN)"""
 	print("[%s] [%s] Checking with miniwdl..." % (datetime.datetime.now(), wdl_to_check))
 	try:
 		subprocess.check_call(["miniwdl", "check", wdl_to_check], stdout=subprocess.DEVNULL)
@@ -51,10 +55,11 @@ def passes_miniwdl_check(wdl_to_check: str) -> bool:
 	print("[%s] [%s] Passed miniwdl" % (datetime.datetime.now(), wdl_to_check))
 	return True
 
-def passes_womtool_validate(wdl_to_check: str, womtool_path: str) -> bool:
+def passes_womtool_validate(wdl_to_check: str, womtool_jar: str) -> bool:
+	"""Does `java -jar womtool_jar validate wdl_to_check` return 0?"""
 	print("[%s] [%s] Checking with womtool..." % (datetime.datetime.now(), wdl_to_check))
 	try:
-		subprocess.check_call(["java", "-jar", womtool_path,
+		subprocess.check_call(["java", "-jar", womtool_jar,
 		 "validate", wdl_to_check], stdout=subprocess.DEVNULL)
 	except subprocess.CalledProcessError as oops:
 		# womtool will print more useful stderr to command line
@@ -75,8 +80,9 @@ def passes_womtool_validate(wdl_to_check: str, womtool_path: str) -> bool:
 #	else:
 #		os.system("rm -rf %s*" % today)
 
-def main(womtool_path: str):
-	syntaxcheck_passed = syntax_check(womtool_path)
+def main(womtool_jar: str):
+	"""Check syntax and run five workflows"""
+	syntaxcheck_passed = syntax_check(womtool_jar)
 	print("Checking workflows...")
 	print("Not checking check_task_outputs, as its inputs are not local...")
 
@@ -137,6 +143,5 @@ if __name__ == "__main__":
 		if not womtool_path.endswith(".jar"):
 			print("womtool doesn't have .jar extension? Make sure you to specify the jar itself, not only the path leading up to it")
 			sys.exit(1)
+		assert os.path.isfile(womtool_path), f"User specified womtool is {womtool_path} but there is no file there!"
 		main(womtool_path)
-
-

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,8 +2,8 @@
 
 # Requirements: * Python 3.7 or higher (to run miniwdl)
 #               * Java (to run womtool)
-#               * miniwdl: https://github.com/chanzuckerberg/miniwdl
-#               * womtool: https://github.com/broadinstitute/cromwell
+#               * womtool: https://github.com/broadinstitute/cromwell (you only need womtool, not Cromwell)
+#               * miniwdl: https://github.com/chanzuckerberg/miniwdl (must be on path, or run this script in a venv)
 
 # pylint: disable=bad-indentation,consider-using-f-string,line-too-long,missing-module-docstring,trailing-whitespace
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,11 +1,16 @@
 # Meant to be run from the root directory of the repo.
 
+# Requirements: * Python 3.7 or higher (to run miniwdl)
+#               * Java (to run womtool)
+#               * miniwdl: https://github.com/chanzuckerberg/miniwdl
+#               * womtool: https://github.com/broadinstitute/cromwell  
+
 import subprocess
 import datetime
 import sys
 import os
 
-skip_syntax_check = True # just for debugging
+skip_syntax_check = False
 _failed_ = False
 
 def check_workflow(wf_name, subprocess_array):
@@ -25,7 +30,8 @@ def check_workflow(wf_name, subprocess_array):
 		_failed_ = True
 	tempfile.close()
 
-def syntax_check():
+def syntax_check(womtool_path: str):
+	assert os.path.isfile(womtool_path), f"User specified womtool is {womtool_path} but there is no file there"
 	print("[%s] Check syntax via womtool..." % datetime.datetime.now())
 	for root, dirs, files in os.walk(".", topdown=True):
 		for file in files:
@@ -33,7 +39,7 @@ def syntax_check():
 				this_wdl = os.path.join(root, file)
 				print("[%s] Checking %s..." % (datetime.datetime.now(), this_wdl))
 				try:
-					subprocess.check_call(["java", "-jar", "/Applications/womtool-76.jar",
+					subprocess.check_call(["java", "-jar", womtool_path,
 					 "validate", "%s" % this_wdl], stdout=subprocess.DEVNULL)
 				except subprocess.CalledProcessError as oops:
 					# womtool will print more useful stderr to command line
@@ -55,9 +61,9 @@ def cleanup_miniwdl_extras():
 	else:
 		os.system("rm -rf %s*" % today)
 
-def main():
+def main(womtool_path: str):
 	if not skip_syntax_check:
-		syntax_check()
+		syntax_check(womtool_path)
 	print("Checking workflows...")
 	print("Not checking check_task_outputs, as its inputs are not local...")
 
@@ -105,6 +111,18 @@ def main():
 	cleanup_miniwdl_extras()
 
 if __name__ == "__main__":
-	main()
+	if len(sys.argv) != 2:
+		print("Usage: python tests/tests.py [womtool_jar]")
+		print("Assumptions: ")
+		print(" * Java is on the path")
+		print(" * test_data/ folder from repo is in workdir (i.e. you're running this from the root of the repo")
+		print(" * miniwdl was pip-installed such that `miniwdl` command is on the path")
+		sys.exit(1) # not zero, so this can be caught in CICD
+	else:
+		womtool_path = sys.argv[1]
+		if not womtool_path.endswith(".jar"):
+			print("womtool doesn't have .jar extension? Make sure you to specify the jar itself, not only the path leading up to it")
+			sys.exit(1)
+		main(womtool_path)
 
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Using womtool to check the syntax as that is what Terra relies on
+# Using miniwdl to actually run the workflows as it is less verbose 
+
+echo "$(date +["%r %m-%d-%y"]) Beginning test of checker workflow templates" > output.txt
+
+echo "Checking syntax..."
+echo "$(date +["%r %m-%d-%y"]) Check syntax via womtool" >> output.txt
+for file in $(find checker_tasks/ check_task_outputs/ check_wf_outputs/ check_approximately_equals/ -name '*.wdl' -type f -print);
+do
+	echo ${file} >> output.txt
+	java -jar /Applications/womtool-76.jar validate ${file} >> output.txt
+done
+
+
+echo "Checking workflows..."
+
+echo "$(date +["%r %m-%d-%y"]) Run fuzzycheck via miniwdl" >> output.txt
+miniwdl run check_approximately_equals/fuzzycheck_RData.wdl \
+	testRDatafile=test_data/allele_chr1.RData \
+	truthRDatafile=test_data/truths/allele_chr1.RData \
+	testRDataarray=test_data/allele_chr1.RData \
+	testRDataarray=test_data/allele_chr2.RData \
+	truthRDataarray=test_data/truths/allele_chr1.RData \
+	truthRDataarray=test_data/truths/allele_chr2.RData
+
+echo "$(date +["%r %m-%d-%y"]) Not checking check_task_outputs, as its inputs are not local..." >> output.txt
+
+echo "$(date +["%r %m-%d-%y"]) Run outputs_all_required base case via miniwdl" >> output.txt
+miniwdl run check_wf_outputs/outputs_all_required/parent_req.wdl \
+	file1=test_data/allele_chr1.RData \
+	file2=test_data/truths/allele_chr1.RData \
+	file3=test_data/allele_chr1.RData 
+
+echo "$(date +["%r %m-%d-%y"]) Run outputs_all_required checker case via miniwdl" >> output.txt
+miniwdl run check_wf_outputs/outputs_all_required/template_req.wdl \
+	file1=test_data/NWD176325.005percent.recab.crai \
+	file2=test_data/NWD119836.0005.recab.cram.crai \
+	file3=test_data/NWD119836.0005.recab.crai \
+	singleTruth=test_data/truths/NWD176325.005percent.recab.crai.txt \
+	truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt \
+	truthSet=test_data/truths/NWD119836.0005.recab.crai.txt
+
+
+

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,7 +1,32 @@
 #!/bin/bash
 
-# Using womtool to check the syntax as that is what Terra relies on
-# Using miniwdl to actually run the workflows as it is less verbose 
+# ███████████████████████████████████ LICENSE ██████████████████████████████████
+# Copyright 2022 Aisling "Ash" O'Farrell
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ███████████████████████████████████ NOTES ████████████████████████████████████
+# Purpose: This is a simple sh file that makes sure I do not break my templates.
+#          It is not designed to be a learning resource, but it is relatively
+#          simple and you can base your own tests upon it (per the rules of the
+#          above license). The first step is to check the syntax of all .wdls in
+#          the repository with womtool, which is the same syntax verification
+#          used by Cromwell (which is used by Terra). Actual testing of relevent
+#          workflows is done with miniwdl, as miniwdl is faster than Cromwell
+#          and has much less verbose output.
+#
+# Requirements: * Python 3.7 or higher (to run miniwdl)
+#               * Java (to run womtool)
+#               * miniwdl: https://github.com/chanzuckerberg/miniwdl
+#               * womtool: https://github.com/broadinstitute/cromwell  
+# 
 
 echo "$(date +["%r %m-%d-%y"]) Beginning test of checker workflow templates" > output.txt
 
@@ -42,5 +67,18 @@ miniwdl run check_wf_outputs/outputs_all_required/template_req.wdl \
 	truthSet=test_data/truths/NWD119836.0005.recab.cram.crai.txt \
 	truthSet=test_data/truths/NWD119836.0005.recab.crai.txt
 
+echo "$(date +["%r %m-%d-%y"]) Run outputs_some_optional base case via miniwdl" >> output.txt
+miniwdl run check_wf_outputs/outputs_some_optional/parent_opt.wdl \
+	optionalInput=test_data/NWD119836.0005.recab.cram.crai \
+	requiredInput=test_data/NWD176325.005percent.recab.crai 
+
+echo "$(date +["%r %m-%d-%y"]) Run outputs_some_optional checker case via miniwdl" >> output.txt
+miniwdl run check_wf_outputs/outputs_some_optional/template_opt.wdl \
+	optionalInput=test_data/NWD119836.0005.recab.cram.crai \
+	requiredInput=test_data/NWD176325.005percent.recab.crai \
+	singleTruth=test_data/truths/foo.txt \
+	arrayTruth=test_data/truths/bar.txt \
+	arrayTruth=test_data/truths/second_bar/bar.txt \
+	arrayTruth=test_data/truths/foo.txt 
 
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# This is a simplified version of tests.py
 
 # ███████████████████████████████████ LICENSE ██████████████████████████████████
 # Copyright 2022 Aisling "Ash" O'Farrell


### PR DESCRIPTION
I am currently in the process of handing off a bunch of workflows to CDPH for long-term use, and in the process have been checking all of my dependencies. [myco](https://github.com/aofarrel/myco) has a checker workflow, so it made sense to check back here.

About four years ago, I wrote a testing script for this repo, but I didn't follow up on the PR after implementing the requested changes. You can see that PR here: https://github.com/dockstore/checker-WDL-templates/pull/28

I've since reworked the Python script to be much cleaner. I have tested this locally and it runs as expected. This PR being pulled is not a requirement for CDPH handoff, but it might make some further improvements easier to integrate.

Changes since #28:

* Womtool jar is no longer hardcoded to a particular location nor version (womtool's filename typically includes the version number), but now must be specified as the second arg of the script
* Expectations are a little clearer, including saying miniwdl needs to be accessible on the path, which is less likely to be the case nowadays since venvs are becoming more and more trendy (for good reason). A user should be able to run this script in a venv that includes miniwdl just fine.
* Now runs `miniwdl check` in addition to `womtool validate`
  * This raises questions about ./check_task_outputs/example_taskcalling.wdl , see below 
* Python is less gross in general (no abuse of global variables, etc)

The python script could be improved further, but it is functional as-is, and I want to keep the scope of this PR from becoming too big.

## The problem with  ./check_task_outputs/example_taskcalling.wdl 
It turns out ./check_task_outputs/example_taskcalling.wdl passes womtool, but does not pass the newly added `miniwdl check`. However, example_taskcalling.wdl is already problematic because its required test files (see JSON at that path) were, to my memory, deleted when the `gs://topmed_workflow_testing bucket` was deleted by mistake by a UCSC employee circa late 2022. I have a vague recollection of some of these files mirrored elsewhere, but I can't recall where or all of them are. Since that bucket was deleted I have been using `gs://ucsc-pathogen-genomics-public` for my tuberculosis stuff, but the topmed stuff isn't there.

It is a very large workflow that has a non-trivial number of outputs. I don't really have the bandwidth to regenerate all of them at this time, and to be honest, it's kind of a bad example anyway: Very large, compute-intense, data is not truly open. At the same time, it is arguably a good "maximal" example.

TLDR: Seeking input regarding:
* the fate of analysis_pipeline_wdl's (https://dockstore.org/organizations/bdcatalyst/collections/UWGACAncestryRelatedness) test files, now that gs://topmed_workflow_testing has vanished
* if ./check_task_outputs/example_taskcalling.wdl should be deleted anyway
  * if yes, what should replace it, if anything?